### PR TITLE
Discard master/slave lingo

### DIFF
--- a/src/MySQLdb_connect.py
+++ b/src/MySQLdb_connect.py
@@ -227,7 +227,7 @@ TypeError: 'database' is an invalid keyword argument for this function
 (24, 'counterfoil street', 'Owen Sound', 'Canada', 'Ontario', 'H9C U4H')
 (25, 'screamingly street', 'Owen Sound', 'Canada', 'Ontario', 'Y1S W6Z')
 (26, 'misorganized street', 'Barrie', 'Canada', 'Ontario', 'L8M B4X')
-(27, 'postmastership street', 'Waterloo', 'Canada', 'Ontario', 'T6X C7C')
+(27, 'postmainship street', 'Waterloo', 'Canada', 'Ontario', 'T6X C7C')
 (28, 'diazotize street', 'Milton', 'Canada', 'Ontario', 'U1V M3I')
 (29, 'difficultly street', 'Toronto', 'Canada', 'Ontario', 'B5C M9A')
 (30, 'chylophyllously street', 'Waterloo', 'Canada', 'Ontario', 'C8S W1R')


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.